### PR TITLE
NameRes v1.2.0 release

### DIFF
--- a/api/resources/openapi.yml
+++ b/api/resources/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Name Resolver
-  version: 1.1.0
+  version: 1.2.0
   email: bizon@renci.org
   name: Chris Bizon
   x-id: https://github.com/cbizon


### PR DESCRIPTION
This PR will prepare (and tag) a v1.2.0 release. Once I've confirmed that the generated Docker image works, I'll submit this for review.

(This should have been the v1.1.0 release, but I accidentally tagged that in the wrong place -- sorry!)