### PR TITLE
Added a GitHub Action to build and publish NameRes Docker images in GitHub

### DIFF
--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,7 +1,6 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,4 +1,4 @@
-name: 'Release a new version to Github Packages'
+name: 'Release a new version of NameResolution to Github Packages'
 
 on:
     push:
@@ -12,6 +12,9 @@ jobs:
     push_to_registry:
         name: Push Docker image to GitHub Packages tagged with "latest" and version number.
         runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          packages: write
         steps:
             - name: Check out the repo
               uses: actions/checkout@v2

--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,6 +1,7 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-nameres-loading.yml
+++ b/.github/workflows/release-nameres-loading.yml
@@ -1,6 +1,7 @@
 name: 'Release a new version of NameResolution Data Loading to Github Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-nameres-loading.yml
+++ b/.github/workflows/release-nameres-loading.yml
@@ -1,7 +1,6 @@
 name: 'Release a new version of NameResolution Data Loading to Github Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-nameres-loading.yml
+++ b/.github/workflows/release-nameres-loading.yml
@@ -33,6 +33,10 @@ jobs:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
+            # Setting up Docker Buildx with docker-container driver is required
+            # at the moment to be able to use a subdirectory with Git context
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
             - name: Push to GitHub Packages
               uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
               with:

--- a/.github/workflows/release-nameres-loading.yml
+++ b/.github/workflows/release-nameres-loading.yml
@@ -1,0 +1,43 @@
+name: 'Release a new version of NameResolution Data Loading to Github Packages'
+
+on:
+    push:
+    release:
+        types: [published]
+
+env:
+    REGISTRY: ghcr.io
+
+jobs:
+    push_to_registry:
+        name: Push Docker image to GitHub Packages tagged with "latest" and version number.
+        runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          packages: write
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v2
+            - name: Get the version
+              id: get_version
+              run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+              with:
+                images:
+                    ghcr.io/${{ github.repository }}-data-loading
+            - name: Login to ghcr
+              uses: docker/login-action@v1
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Push to GitHub Packages
+              uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+              with:
+                  context: data-loading
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  build-args: BRANCH_NAME=${{ github.event.release.target_commitish }}

--- a/.github/workflows/release-nameres-loading.yml
+++ b/.github/workflows/release-nameres-loading.yml
@@ -36,7 +36,7 @@ jobs:
             - name: Push to GitHub Packages
               uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
               with:
-                  context: data-loading
+                  context: "{{defaultContext}}:data-loading"
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-nameres-loading.yml
+++ b/.github/workflows/release-nameres-loading.yml
@@ -38,7 +38,7 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
             - name: Push to GitHub Packages
-              uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+              uses: docker/build-push-action@v4
               with:
                   context: "{{defaultContext}}:data-loading"
                   push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: 'Release a new version to Github Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/api/server.py
+++ b/api/server.py
@@ -127,8 +127,8 @@ async def lookup_curies(
         LOGGER.error("Solr REST error: %s", response.text)
         response.raise_for_status()
     response = response.json()
-    output = [ {"curie": doc["curie"], "label":doc["preferred_name"], "synonyms": doc["names"],
-                "types": [f"biolink:{d}" for d in doc["types"]]}
+    output = [ {"curie": doc.get("curie", ""), "label":doc.get("preferred_name", ""), "synonyms": doc.get("names", []),
+                "types": [f"biolink:{d}" for d in doc.get("types", [])]}
                for doc in response["response"]["docs"]]
     return output
 

--- a/data-loading/kubernetes/nameres-loading-data.k8s.yaml
+++ b/data-loading/kubernetes/nameres-loading-data.k8s.yaml
@@ -2,12 +2,12 @@
 # nameres-loading-data is a directory for storing synonym files,
 # the generated Solr back and its compressed version.
 #
-# As of 2022dec11, this directory needs to contain:
-# - 38G of synonym files (in CSV and JSON)
-# - 30G of snapshot.backup files moved here from Solr
-# - 23G of snapshot.backup.tar.gz after compressing
-# Therefore it needs to be a minimum of 100G. I'm going to set a
-# size of 150G in case we need some extra space.
+# As of 2023jun1, this directory needs to contain:
+# - 129G of synonym files (in JSON)
+# - 119G of snapshot.backup files moved here from Solr
+# - 100G of snapshot.backup.tar.gz after compressing
+# Therefore it needs to be a minimum of 400G. I'm going to set a
+# size of 400G in case we need some extra space.
 
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -20,5 +20,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 300Gi
+      storage: 400Gi
   storageClassName: basic

--- a/data-loading/kubernetes/nameres-loading-data.k8s.yaml
+++ b/data-loading/kubernetes/nameres-loading-data.k8s.yaml
@@ -5,8 +5,8 @@
 # As of 2023jun1, this directory needs to contain:
 # - 129G of synonym files (in JSON)
 # - 119G of snapshot.backup files moved here from Solr
-# - 100G of snapshot.backup.tar.gz after compressing
-# Therefore it needs to be a minimum of 400G. I'm going to set a
+# - 85G of snapshot.backup.tar.gz after compressing
+# Therefore it needs to be a minimum of 350G. I'm going to set a
 # size of 400G in case we need some extra space.
 
 apiVersion: v1

--- a/data-loading/kubernetes/nameres-loading.k8s.yaml
+++ b/data-loading/kubernetes/nameres-loading.k8s.yaml
@@ -10,7 +10,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: nameres-loading
-    image: ggvaidya/nameres-data-loading:dev
+    image: ghcr.io/translatorsri/nameresolution-data-loading:change-docker-to-use-current-code
     imagePullPolicy: Always
     # I just need something to run while I figure out how to make this work
     command: [ "/bin/bash", "-c", "--" ]


### PR DESCRIPTION
This PR adds a GitHub Action to build two Docker images for NameRes -- a `nameresolution` image based on `./Dockerfile`, which can act as a web host for a correctly configured Solr database (see setup.sh for code on building this), and a `nameresolution-data-loading` image based on the `./data-loading/Dockerfile`, which can be used to load a Solr database with the synonym files produced by Babel (after https://github.com/TranslatorSRI/Babel/pull/113). You can see these Docker images at https://github.com/orgs/TranslatorSRI/packages?repo_name=NameResolution

Also contains a minor bug fix: we now allow a document to be missing a preferred_name, names, curie or types field and provide blank output in that case.

Should be merged after PR #53.