### PR TITLE
Add GET endpoints for queries and a redirect for `/`

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -49,6 +49,8 @@ class Request(BaseModel):
 
 @app.get(
     "/reverse_lookup",
+    summary="Look up synonyms for a CURIE.",
+    description="Returns a list of synonyms for a particular CURIE.",
     response_model=Dict[str, List[str]],
     tags=["lookup"],
 )
@@ -63,6 +65,8 @@ async def lookup_names_get(
 
 @app.post(
     "/reverse_lookup",
+    summary="Look up synonyms for a CURIE.",
+    description="Returns a list of synonyms for a particular CURIE.",
     response_model=Dict[str, List[str]],
     tags=["lookup"],
 )
@@ -105,7 +109,12 @@ class LookupResult(BaseModel):
     types: List[str]
 
 
-@app.get("/lookup", response_model=List[LookupResult], tags=["lookup"])
+@app.get("/lookup",
+     summary="Look up cliques for a fragment of a name or synonym.",
+     description="Returns cliques with a name or synonym that contains a specified string.",
+     response_model=List[LookupResult],
+     tags=["lookup"]
+)
 async def lookup_curies_get(
         string: str,
         offset: int = 0,
@@ -116,7 +125,12 @@ async def lookup_curies_get(
     return await lookup(string, offset, limit, biolink_type)
 
 
-@app.post("/lookup", response_model=List[LookupResult], tags=["lookup"])
+@app.post("/lookup",
+    summary="Look up cliques for a fragment of a name or synonym.",
+    description="Returns cliques with a name or synonym that contains a specified string.",
+    response_model=List[LookupResult],
+    tags=["lookup"]
+)
 async def lookup_curies_post(
         string: str,
         offset: int = 0,

--- a/api/server.py
+++ b/api/server.py
@@ -14,6 +14,7 @@ import re
 from typing import Dict, List
 
 from fastapi import Body, FastAPI
+from fastapi.responses import RedirectResponse
 import httpx
 from pydantic import BaseModel, conint
 from starlette.middleware.cors import CORSMiddleware
@@ -34,7 +35,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-not_alpha = re.compile(r"[\W_]+")
+# If someone tries accessing /, we should redirect them to the Swagger interface.
+@app.get("/", include_in_schema=False)
+async def docs_redirect():
+    return RedirectResponse(url='/docs')
 
 
 class Request(BaseModel):
@@ -121,6 +125,8 @@ async def lookup_curies_post(
 ) -> List[LookupResult]:
     """Look up curies from name or fragment."""
     return await lookup(string, offset, limit, biolink_type)
+
+not_alpha = re.compile(r"[\W_]+")
 
 
 async def lookup(string: str,


### PR DESCRIPTION
Closes #29.

This will allow us to link directly to NameRes results from issues and makes it slightly easier to call NameRes.