### PR TITLE
Split the Gene.txt file as well

### DIFF
--- a/data-loading/Makefile
+++ b/data-loading/Makefile
@@ -36,7 +36,8 @@ data/synonyms/done:
 	echo Downloaded synonyms from ${SYNONYMS_URL}
 	split -d -l 10000000 data/synonyms/Protein.txt data/synonyms/Protein.txt. && rm data/synonyms/Protein.txt
 	split -d -l 10000000 data/synonyms/SmallMolecule.txt data/synonyms/SmallMolecule.txt. && rm data/synonyms/SmallMolecule.txt
-	echo Split Protein.txt and SmallMolecule.txt and deleted the original files.
+	split -d -l 10000000 data/synonyms/Gene.txt data/synonyms/Gene.txt. && rm data/synonyms/Gene.txt
+	echo Split Protein.txt, SmallMolecule.txt and Gene.txt, and deleted the original files.
 	touch $@
 
 # Step 3. Start Solr server.


### PR DESCRIPTION
We currently split the Protein and SmallMolecule files, as they are huge. but Gene.txt is 19.5G uncompressed, and so should also be split before uploading to Solr. This PR does that.