### PR TITLE
Replace search algorithm with eDisMax and prefer preferred name matches

### DIFF
--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,7 +1,6 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,6 +1,7 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/api/server.py
+++ b/api/server.py
@@ -186,8 +186,6 @@ async def lookup_curies_post(
     """
     return await lookup(string, offset, limit, biolink_type, only_prefixes)
 
-not_alpha = re.compile(r"[\W_]+")
-
 
 async def lookup(string: str,
            offset: int = 0,
@@ -213,7 +211,7 @@ async def lookup(string: str,
 
     # First, we need forms of the query that are (1) lowercase, and (2) missing any double-quotes so we can double-quote it.
     string_lc = string.lower()
-    string_lc_no_dq = string_lc.replace('\"', '\'')
+    string_lc_no_dq = string_lc.replace('"', '\'')
 
     # Then we combine it into a query that allows for incomplete words.
     query = f"\"{string_lc_no_dq}\" OR \"{string_lc_no_dq}\"*"

--- a/api/server.py
+++ b/api/server.py
@@ -262,8 +262,8 @@ async def lookup(string: str,
         LOGGER.error("Solr REST error: %s", response.text)
         response.raise_for_status()
     response = response.json()
-    output = [ {"curie": doc.get("curie", ""), "label":doc.get("preferred_name", ""), "synonyms": doc.get("names", []),
-                "types": [f"biolink:{d}" for d in doc.get("types", [])]}
+    output = [ LookupResult(curie=doc.get("curie", ""), label=doc.get("preferred_name", ""), synonyms=doc.get("names", []),
+                types=[f"biolink:{d}" for d in doc.get("types", [])])
                for doc in response["response"]["docs"]]
 
     # One downside to using the 'OR' query is that we can end up getting the same
@@ -272,9 +272,9 @@ async def lookup(string: str,
     seen = set()
     deduplicated = []
     for o in output:
-        if o in seen:
+        if o.curie in seen:
             continue
-        seen.add(o)
+        seen.add(o.curie)
         deduplicated.append(o)
 
     return deduplicated

--- a/api/server.py
+++ b/api/server.py
@@ -238,14 +238,13 @@ async def lookup(string: str,
     params = {
         "query": {
             "edismax": {
-                "query": string_lc,
-                "qf": "preferred_name^1000 names",
+                "query": string,
+                "qf": "preferred_name_exactish^10000 preferred_name^100 names",
             },
         },
         "limit": limit,
         "offset": offset,
-        "filter": filters,
-        "fields": "curie,names,preferred_name,types,shortest_name_length",
+        "filter": filters
     }
     print(f"Query: {json.dumps(params)}")
 

--- a/api/server.py
+++ b/api/server.py
@@ -209,12 +209,16 @@ async def lookup(string: str,
     # This version of the code replaces the previous facet-based multiple-query search NameRes used to have
     # (see https://github.com/TranslatorSRI/NameResolution/blob/v1.2.0/api/server.py#L79-L165)
 
-    # First, we need forms of the query that are (1) lowercase, and (2) missing any double-quotes so we can double-quote it.
+    # First, we need forms of the query that are (1) lowercase, and (2) missing any Lucene special characters
+    # (as listed at https://solr.apache.org/guide/solr/latest/query-guide/standard-query-parser.html#escaping-special-characters)
     string_lc = string.lower()
+    string_lc_escaped = re.sub(r'([!(){}\[\]^"~*?:/+-])', '\\\1', string_lc)
+
+    # We need to escape '&&' and '||' specially, since they are double-character sequences.
+    string_lc_escaped = string_lc_escaped.replace('&&', '\\&\\&').replace('||', '\\|\\|')
 
     # Then we combine it into a query that allows for incomplete words.
-    # (Double-quoting these phrases seems to cause strange matching issues, so I'm going back to using round brackets to group terms.)
-    query = f"({string_lc}) OR ({string_lc})*"
+    query = f"({string_lc_escaped}) OR ({string_lc_escaped}*)"
 
     # Apply filters as needed.
     # Biolink type filter

--- a/api/server.py
+++ b/api/server.py
@@ -211,10 +211,10 @@ async def lookup(string: str,
 
     # First, we need forms of the query that are (1) lowercase, and (2) missing any double-quotes so we can double-quote it.
     string_lc = string.lower()
-    string_lc_no_dq = string_lc.replace('"', '\'')
 
     # Then we combine it into a query that allows for incomplete words.
-    query = f"\"{string_lc_no_dq}\" OR \"{string_lc_no_dq}\"*"
+    # (Double-quoting these phrases seems to cause strange matching issues, so I'm going back to using round brackets to group terms.)
+    query = f"({string_lc}) OR ({string_lc})*"
 
     # Apply filters as needed.
     # Biolink type filter

--- a/api/server.py
+++ b/api/server.py
@@ -240,8 +240,10 @@ async def lookup(string: str,
             "edismax": {
                 "query": string,
                 # qf = query fields, i.e. how should we boost these fields if they contain the same fields as the input.
+                # https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#qf-query-fields-parameter
                 "qf": "preferred_name_exactish^100 preferred_name^10 names",
                 # pf = phrase fields, i.e. how should we boost these fields if they contain the entire search phrase.
+                # https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#pf-phrase-fields-parameter
                 "pf": "preferred_name_exactish^100000 preferred_name^10000 names^1000",
             },
         },

--- a/api/server.py
+++ b/api/server.py
@@ -265,7 +265,19 @@ async def lookup(string: str,
     output = [ {"curie": doc.get("curie", ""), "label":doc.get("preferred_name", ""), "synonyms": doc.get("names", []),
                 "types": [f"biolink:{d}" for d in doc.get("types", [])]}
                for doc in response["response"]["docs"]]
-    return output
+
+    # One downside to using the 'OR' query is that we can end up getting the same
+    # query returned by both sides of the OR query, which Solr doesn't de-duplicate
+    # for us. So we need to de-duplicate them ourselves.
+    seen = set()
+    deduplicated = []
+    for o in output:
+        if o in seen:
+            continue
+        seen.add(o)
+        deduplicated.append(o)
+
+    return deduplicated
 
 # Override open api schema with custom schema
 app.openapi_schema = construct_open_api_schema(app)

--- a/api/server.py
+++ b/api/server.py
@@ -239,7 +239,10 @@ async def lookup(string: str,
         "query": {
             "edismax": {
                 "query": string,
-                "qf": "preferred_name_exactish^10000 preferred_name^100 names",
+                # qf = query fields, i.e. how should we boost these fields if they contain the same fields as the input.
+                "qf": "preferred_name_exactish^100 preferred_name^10 names",
+                # pf = phrase fields, i.e. how should we boost these fields if they contain the entire search phrase.
+                "pf": "preferred_name_exactish^100000 preferred_name^10000 names^1000",
             },
         },
         "limit": limit,

--- a/api/server.py
+++ b/api/server.py
@@ -215,6 +215,9 @@ async def lookup(string: str,
     string_lc = string.lower()
     string_lc_no_dq = string_lc.replace('\"', '\'')
 
+    # Then we combine it into a query that allows for incomplete words.
+    query = f"\"{string_lc_no_dq}\" OR \"{string_lc_no_dq}\"*"
+
     # Apply filters as needed.
     # Biolink type filter
     filters = []
@@ -232,19 +235,16 @@ async def lookup(string: str,
             prefix_filters.append(f"curie:/{prefix}:.*/")
         filters.append(" OR ".join(prefix_filters))
 
-    # TODO: run this with the filter, then without.
-    # filters.append(f"preferred_name:\"{string_lc.replace('\"')}\"")
-
     params = {
         "query": {
             "edismax": {
-                "query": string,
+                "query": query,
                 # qf = query fields, i.e. how should we boost these fields if they contain the same fields as the input.
                 # https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#qf-query-fields-parameter
                 "qf": "preferred_name_exactish^100 preferred_name^10 names",
                 # pf = phrase fields, i.e. how should we boost these fields if they contain the entire search phrase.
                 # https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#pf-phrase-fields-parameter
-                "pf": "preferred_name_exactish^100000 preferred_name^10000 names^1000",
+                "pf": "preferred_name_exactish^100000 preferred_name^10000 names^1000"
             },
         },
         "limit": limit,

--- a/api/server.py
+++ b/api/server.py
@@ -243,10 +243,10 @@ async def lookup(string: str,
                 "query": query,
                 # qf = query fields, i.e. how should we boost these fields if they contain the same fields as the input.
                 # https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#qf-query-fields-parameter
-                "qf": "preferred_name_exactish^20 preferred_name names",
+                "qf": "preferred_name_exactish^10 preferred_name^1 names^1",
                 # pf = phrase fields, i.e. how should we boost these fields if they contain the entire search phrase.
                 # https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#pf-phrase-fields-parameter
-                "pf": "preferred_name_exactish^30 preferred_name^10 names^10"
+                "pf": "preferred_name_exactish^20 preferred_name^3 names^2"
             },
         },
         "limit": limit,

--- a/api/server.py
+++ b/api/server.py
@@ -212,7 +212,7 @@ async def lookup(string: str,
     # First, we need forms of the query that are (1) lowercase, and (2) missing any Lucene special characters
     # (as listed at https://solr.apache.org/guide/solr/latest/query-guide/standard-query-parser.html#escaping-special-characters)
     string_lc = string.lower()
-    string_lc_escaped = re.sub(r'([!(){}\[\]^"~*?:/+-])', '\\\1', string_lc)
+    string_lc_escaped = re.sub(r'([!(){}\[\]^"~*?:/+-])', r'\\1', string_lc)
 
     # We need to escape '&&' and '||' specially, since they are double-character sequences.
     string_lc_escaped = string_lc_escaped.replace('&&', '\\&\\&').replace('||', '\\|\\|')

--- a/api/server.py
+++ b/api/server.py
@@ -243,17 +243,17 @@ async def lookup(string: str,
                 "query": query,
                 # qf = query fields, i.e. how should we boost these fields if they contain the same fields as the input.
                 # https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#qf-query-fields-parameter
-                "qf": "preferred_name_exactish^100 preferred_name^10 names",
+                "qf": "preferred_name_exactish^10 preferred_name names",
                 # pf = phrase fields, i.e. how should we boost these fields if they contain the entire search phrase.
                 # https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#pf-phrase-fields-parameter
-                "pf": "preferred_name_exactish^100000 preferred_name^10000 names^1000"
+                "pf": "preferred_name_exactish^1000 preferred_name^20 names^10"
             },
         },
         "limit": limit,
         "offset": offset,
         "filter": filters
     }
-    print(f"Query: {json.dumps(params)}")
+    logging.debug(f"Query: {json.dumps(params)}")
 
     query_url = f"http://{SOLR_HOST}:{SOLR_PORT}/solr/name_lookup/select"
     async with httpx.AsyncClient(timeout=None) as client:

--- a/api/server.py
+++ b/api/server.py
@@ -57,12 +57,13 @@ class Request(BaseModel):
     tags=["lookup"],
 )
 async def lookup_names_get(
-        request: Request = Body(..., example={
-            "curies": ["MONDO:0005737", "MONDO:0009757"],
-        }),
+        curies: Annotated[str, Query(
+            examples=["MONDO:0005737", "MONDO:0009757"],
+            description="A list of CURIEs to look up synonyms for."
+        )]
 ) -> Dict[str, List[str]]:
     """Returns a list of synonyms for a particular CURIE."""
-    return await reverse_lookup(request.curies)
+    return await reverse_lookup(curies)
 
 
 @app.post(

--- a/api/server.py
+++ b/api/server.py
@@ -243,10 +243,10 @@ async def lookup(string: str,
                 "query": query,
                 # qf = query fields, i.e. how should we boost these fields if they contain the same fields as the input.
                 # https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#qf-query-fields-parameter
-                "qf": "preferred_name_exactish^10 preferred_name names",
+                "qf": "preferred_name_exactish^20 preferred_name names",
                 # pf = phrase fields, i.e. how should we boost these fields if they contain the entire search phrase.
                 # https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#pf-phrase-fields-parameter
-                "pf": "preferred_name_exactish^1000 preferred_name^20 names^10"
+                "pf": "preferred_name_exactish^30 preferred_name^10 names^10"
             },
         },
         "limit": limit,

--- a/api/server.py
+++ b/api/server.py
@@ -266,18 +266,7 @@ async def lookup(string: str,
                 types=[f"biolink:{d}" for d in doc.get("types", [])])
                for doc in response["response"]["docs"]]
 
-    # One downside to using the 'OR' query is that we can end up getting the same
-    # query returned by both sides of the OR query, which Solr doesn't de-duplicate
-    # for us. So we need to de-duplicate them ourselves.
-    seen = set()
-    deduplicated = []
-    for o in output:
-        if o.curie in seen:
-            continue
-        seen.add(o.curie)
-        deduplicated.append(o)
-
-    return deduplicated
+    return output
 
 # Override open api schema with custom schema
 app.openapi_schema = construct_open_api_schema(app)

--- a/api/server.py
+++ b/api/server.py
@@ -212,7 +212,7 @@ async def lookup(string: str,
     # First, we need forms of the query that are (1) lowercase, and (2) missing any Lucene special characters
     # (as listed at https://solr.apache.org/guide/solr/latest/query-guide/standard-query-parser.html#escaping-special-characters)
     string_lc = string.lower()
-    string_lc_escaped = re.sub(r'([!(){}\[\]^"~*?:/+-])', r'\\1', string_lc)
+    string_lc_escaped = re.sub(r'([!(){}\[\]^"~*?:/+-])', r'\\\g<0>', string_lc)
 
     # We need to escape '&&' and '||' specially, since they are double-character sequences.
     string_lc_escaped = string_lc_escaped.replace('&&', '\\&\\&').replace('||', '\\|\\|')

--- a/data-loading/Makefile
+++ b/data-loading/Makefile
@@ -8,7 +8,7 @@
 SYNONYMS_URL=https://stars.renci.org/var/babel_outputs/2022dec2-2/synonyms/
 
 # How much memory should Solr use.
-SOLR_MEM=64G
+SOLR_MEM=120G
 
 # SOLR_DIR should be set up to point to the Solr data directory (usually /var/solr)
 # and SOLR_EXEC should be set up to point to the Solr executable.

--- a/data-loading/Makefile
+++ b/data-loading/Makefile
@@ -8,7 +8,7 @@
 SYNONYMS_URL=https://stars.renci.org/var/babel_outputs/2022dec2-2/synonyms/
 
 # How much memory should Solr use.
-SOLR_MEM=120G
+SOLR_MEM=220G
 
 # SOLR_DIR should be set up to point to the Solr data directory (usually /var/solr)
 # and SOLR_EXEC should be set up to point to the Solr executable.

--- a/data-loading/kubernetes/nameres-loading-data.k8s.yaml
+++ b/data-loading/kubernetes/nameres-loading-data.k8s.yaml
@@ -20,5 +20,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 400Gi
+      storage: 500Gi
   storageClassName: basic

--- a/data-loading/kubernetes/nameres-loading-solr.k8s.yaml
+++ b/data-loading/kubernetes/nameres-loading-solr.k8s.yaml
@@ -14,5 +14,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 300Gi
+      storage: 400Gi
   storageClassName: basic

--- a/data-loading/kubernetes/nameres-loading.k8s.yaml
+++ b/data-loading/kubernetes/nameres-loading.k8s.yaml
@@ -25,12 +25,12 @@ spec:
     resources:
       requests:
         ephemeral-storage: "1G"
-        memory: "64G"
-        cpu: "4"
+        memory: "128G"
+        cpu: "6"
       limits:
         ephemeral-storage: "1G"
         memory: "128G"
-        cpu: "4"
+        cpu: "8"
   volumes:
     - name: nameres-loading-solr
       persistentVolumeClaim:

--- a/data-loading/kubernetes/nameres-loading.k8s.yaml
+++ b/data-loading/kubernetes/nameres-loading.k8s.yaml
@@ -25,11 +25,11 @@ spec:
     resources:
       requests:
         ephemeral-storage: "1G"
-        memory: "128G"
+        memory: "220G"
         cpu: "6"
       limits:
         ephemeral-storage: "1G"
-        memory: "150G"
+        memory: "256G"
         cpu: "8"
   volumes:
     - name: nameres-loading-solr

--- a/data-loading/kubernetes/nameres-loading.k8s.yaml
+++ b/data-loading/kubernetes/nameres-loading.k8s.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: "6"
       limits:
         ephemeral-storage: "1G"
-        memory: "128G"
+        memory: "150G"
         cpu: "8"
   volumes:
     - name: nameres-loading-solr

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ httpx
 uvicorn
 pyyaml
 jsonlines
+
+# For testing
+pytest

--- a/tests/data/test-synonyms.json
+++ b/tests/data/test-synonyms.json
@@ -5,6 +5,7 @@
             "antiparkinson agent"
         ],
         "preferred_name": "antiparkinson agent",
+        "preferred_name_exactish": "antiparkinson agent",
         "types": [
             "NamedThing"
         ],
@@ -38,6 +39,7 @@
             "beta-site Alzheimer's amyloid precursor protein cleaving enzyme 1 (BACE1) inhibitors"
         ],
         "preferred_name": "BACE1 inhibitor",
+        "preferred_name_exactish": "BACE1 inhibitor",
         "types": [
             "NamedThing"
         ],
@@ -49,6 +51,7 @@
             "Parkinsonian disease"
         ],
         "preferred_name": "parkinsonian disorder",
+        "preferred_name_exactish": "parkinsonian disorder",
         "types": [
             "Disease",
             "DiseaseOrPhenotypicFeature",
@@ -68,6 +71,7 @@
             "Parkinsonian tremor"
         ],
         "preferred_name": "Resting tremor",
+        "preferred_name_exactish": "Resting tremor",
         "types": [
             "PhenotypicFeature",
             "DiseaseOrPhenotypicFeature",
@@ -85,6 +89,7 @@
             "Late-onset form of familial Alzheimer disease"
         ],
         "preferred_name": "Alzheimer disease",
+        "preferred_name_exactish": "Alzheimer disease",
         "types": [
             "Disease",
             "DiseaseOrPhenotypicFeature",
@@ -102,6 +107,7 @@
             "Parkinsonism with favourable response to dopaminergic medication"
         ],
         "preferred_name": "Parkinsonism with favorable response to dopaminergic medication",
+        "preferred_name_exactish": "Parkinsonism with favorable response to dopaminergic medication",
         "types": [
             "PhenotypicFeature",
             "DiseaseOrPhenotypicFeature",

--- a/tests/data/test-synonyms.json
+++ b/tests/data/test-synonyms.json
@@ -5,7 +5,6 @@
             "antiparkinson agent"
         ],
         "preferred_name": "antiparkinson agent",
-        "preferred_name_exactish": "antiparkinson agent",
         "types": [
             "NamedThing"
         ],
@@ -39,7 +38,6 @@
             "beta-site Alzheimer's amyloid precursor protein cleaving enzyme 1 (BACE1) inhibitors"
         ],
         "preferred_name": "BACE1 inhibitor",
-        "preferred_name_exactish": "BACE1 inhibitor",
         "types": [
             "NamedThing"
         ],
@@ -51,7 +49,6 @@
             "Parkinsonian disease"
         ],
         "preferred_name": "parkinsonian disorder",
-        "preferred_name_exactish": "parkinsonian disorder",
         "types": [
             "Disease",
             "DiseaseOrPhenotypicFeature",
@@ -71,7 +68,6 @@
             "Parkinsonian tremor"
         ],
         "preferred_name": "Resting tremor",
-        "preferred_name_exactish": "Resting tremor",
         "types": [
             "PhenotypicFeature",
             "DiseaseOrPhenotypicFeature",
@@ -89,7 +85,6 @@
             "Late-onset form of familial Alzheimer disease"
         ],
         "preferred_name": "Alzheimer disease",
-        "preferred_name_exactish": "Alzheimer disease",
         "types": [
             "Disease",
             "DiseaseOrPhenotypicFeature",
@@ -107,7 +102,6 @@
             "Parkinsonism with favourable response to dopaminergic medication"
         ],
         "preferred_name": "Parkinsonism with favorable response to dopaminergic medication",
-        "preferred_name_exactish": "Parkinsonism with favorable response to dopaminergic medication",
         "types": [
             "PhenotypicFeature",
             "DiseaseOrPhenotypicFeature",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -56,14 +56,23 @@ def test_hyphens():
     params = {'string': 'beta-secretase'}
     response = client.post("/lookup", params=params)
     syns = response.json()
-    assert len(syns) == 1
+
+    # Previously, this would actually return only a single result,
+    # but with the updated search algorithm, we return two:
+    # CHEBI:74925 ("beta-secretase") and
+    # MONDO:0011561 ("Alzheimer disease 6"), which has a synonym:
+    #   "plasma Beta-amyloid-42 level quantitative trait locus"
+
+    assert len(syns) == 2
     assert syns[0]["curie"] == 'CHEBI:74925'
+    assert syns[1]["curie"] == 'MONDO:0011561'
     #no hyphen
     params = {'string': 'beta secretase'}
     response = client.post("/lookup", params=params)
     syns = response.json()
-    assert len(syns) == 1
+    assert len(syns) == 2
     assert syns[0]["curie"] == 'CHEBI:74925'
+    assert syns[1]["curie"] == 'MONDO:0011561'
 
 def test_structure():
     client = TestClient(app)


### PR DESCRIPTION
The current search in NameRes is an adaptation and simplification of the [previous search algorithm](https://github.com/TranslatorSRI/NameResolution/blob/v1.2.0/api/server.py#L79-L165), which breaks the input text into alphanumeric fragments and queries them against the `names` field where all the names are stored.

This PR replaces that with a simpler and better search algorithm: we send the input query directly to the Solr [Extended DisMax (eDisMax)](https://solr.apache.org/guide/solr/9_1/query-guide/edismax-query-parser.html), which can handle multiword phrases, boolean operators, and other query components correctly. We use [boosting in query fields](https://solr.apache.org/guide/solr/9_1/query-guide/dismax-query-parser.html#qf-query-fields-parameter) to prioritize exact matches (in the `preferred_name_exactish` field, which is a copy lowercase KeywordTokenizerFactory field for doing "exactish" matches as described in https://stackoverflow.com/a/29105025/27310) over other preferred name matches, which are boosted over all name matches. We then add filters (such as the Biolink types filter and the CURIE prefix filters), offset and limit to the query.

Note that this changes one of the test search results: previously, searching for `beta-secretase` returned a single result CHEBI:74925 ("beta-secretase"), but it will now return an additional result as well (MONDO:0011561, "Alzheimer disease 6"), which has a synonym "plasma Beta-amyloid-42 level quantitative trait locus".

One of these changes (or possibly just upgrading FastAPI) caused the incorrect GET handler for /reverse_lookup to no longer work, so I fixed that as well.

## Details on fields and boosting

This allows to query on three fields:
- `names`: the list of all synonyms in a clique
- `preferred_name`: the preferred name in a clique, parsed into tokens
- `preferred_name_exactish`: the preferred name in a clique

With two ways of boosting:
- query field [qf](https://solr.apache.org/guide/solr/9_1/query-guide/dismax-query-parser.html#qf-query-fields-parameter), which controls how a match is boosted depending on the field in which the result is matched.
  - Current boosts: `preferred_name_exactish^10 preferred_name^1 names^1`
- phrase field [pf](https://solr.apache.org/guide/solr/9_1/query-guide/dismax-query-parser.html#pf-phrase-fields-parameter), which controls how a match is boosted if the search terms are in close promixity to each other.
  - Current boosts: `preferred_name_exactish^20 preferred_name^3 names^2`

This means that our order of boost is:
1. `names^1` as query field
2. `preferred_name^1` as query field
3. `names^2` as phrase field
4. `preferred_name^3` as phrase field
5. `preferred_name_exactish^10` as query field
6. `preferred_name_exactish^20` as phrase field