### PR TITLE
Sort by CURIE suffix

### DIFF
--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,7 +1,6 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,6 +1,7 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/api/server.py
+++ b/api/server.py
@@ -250,6 +250,7 @@ async def lookup(string: str,
                 "pf": "preferred_name_exactish^20 preferred_name^3 names^2"
             },
         },
+        "sort": "score DESC, curie_suffix ASC",
         "limit": limit,
         "offset": offset,
         "filter": filters

--- a/data-loading/setup-and-load-solr.sh
+++ b/data-loading/setup-and-load-solr.sh
@@ -95,7 +95,15 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
             "name":"shortest_name_length",
             "type":"pint",
             "stored":true
-        }
+    	},
+	{
+	    "name":"curie_suffix",
+	    "type":"plong",
+	    "docValues":true,
+	    "stored":true,
+	    "required":false,
+	    "sortMissingLast":true
+	}
     ] }' 'http://localhost:8983/solr/name_lookup/schema'
 
 # Add a copy field to copy preferred_name into preferred_name_exactish.


### PR DESCRIPTION
This PR adds support for sorting results by the CURIE suffix, which requires:
1. Loading the CURIE suffix from the JSON files generated by Babel in data-loading (in PR https://github.com/TranslatorSRI/Babel/pull/179).
2. Indexing it as a long numerical field in data-loading (so we can do a numerical sort instead of an alphabetical sort).
3. Updating our search sort to sort by score first, followed by sorting by the CURIE suffix for entries that have identical scores.