### PR TITLE
Return entire document in reverse lookups

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -53,7 +53,7 @@ class Request(BaseModel):
     "/reverse_lookup",
     summary="Look up synonyms for a CURIE.",
     description="Returns a list of synonyms for a particular CURIE.",
-    response_model=Dict[str, List[str]],
+    response_model=Dict[str, Dict],
     tags=["lookup"],
 )
 async def lookup_names_get(
@@ -61,7 +61,7 @@ async def lookup_names_get(
             example=["MONDO:0005737", "MONDO:0009757"],
             description="A list of CURIEs to look up synonyms for."
         )
-) -> Dict[str, List[str]]:
+) -> Dict[str, Dict]:
     """Returns a list of synonyms for a particular CURIE."""
     return await reverse_lookup(curies)
 
@@ -70,7 +70,7 @@ async def lookup_names_get(
     "/reverse_lookup",
     summary="Look up synonyms for a CURIE.",
     description="Returns a list of synonyms for a particular CURIE.",
-    response_model=Dict[str, List[str]],
+    response_model=Dict[str, Dict],
     tags=["lookup"],
 )
 async def lookup_names_post(
@@ -82,7 +82,7 @@ async def lookup_names_post(
     return await reverse_lookup(request.curies)
 
 
-async def reverse_lookup(curies) -> Dict[str, List[str]]:
+async def reverse_lookup(curies) -> Dict[str, Dict]:
     """Returns a list of synonyms for a particular CURIE."""
     query = f"http://{SOLR_HOST}:{SOLR_PORT}/solr/name_lookup/select"
     curie_filter = " OR ".join(
@@ -102,7 +102,7 @@ async def reverse_lookup(curies) -> Dict[str, List[str]]:
         for curie in curies
     }
     for doc in response_json["response"]["docs"]:
-        output[doc["curie"]].extend(doc["names"])
+        output[doc["curie"]] = doc
     return output
 
 class LookupResult(BaseModel):


### PR DESCRIPTION
We previously returned only the list of synonyms during a reverse-lookup. This PR updates that so that we return all the information we have on that CURIE in the Solr database, including the preferred name, all the synonyms, Biolink type, id and version. An example:

```json
{
  "MONDO:0005737": {
    "curie": "MONDO:0005737",
    "names": [
      "EHF",
      "Ebola",
      "Ebola fever",
      "disease ebola",
      "Ebola disease",
      "Ebola Infection",
      "Infection, Ebola",
      "Ebola virus disease",
      "ebola virus disease",
      "Ebola Virus Disease",
      "Ebolavirus Infection",
      "Ebola virus infection",
      "Ebola Virus Infection",
      "Infection, Ebolavirus",
      "ebola virus infection",
      "Ebolavirus Infections",
      "Infections, Ebolavirus",
      "Virus Infection, Ebola",
      "Infection, Ebola Virus",
      "Ebola hemorrhagic fever",
      "Ebola Hemorrhagic Fever",
      "ebola fever hemorrhagic",
      "ebola hemorrhagic fever",
      "Ebola haemorrhagic fever",
      "ebola haemorrhagic fever",
      "Hemorrhagic Fever, Ebola",
      "EVD - Ebola virus disease",
      "Ebolavirus infectious disease",
      "Ebola virus hemorrhagic fever",
      "Viral hemorrhagic fever, Ebola",
      "Ebola virus disease (disorder)",
      "Ebolavirus disease or disorder",
      "Viral haemorrhagic fever, Ebola",
      "Ebolavirus caused disease or disorder",
      "Ebola virus hemorrhagic fever (diagnosis)"
    ],
    "types": [
      "Disease",
      "DiseaseOrPhenotypicFeature",
      "BiologicalEntity",
      "ThingWithTaxon",
      "NamedThing",
      "Entity"
    ],
    "preferred_name": "Ebola hemorrhagic fever",
    "shortest_name_length": 3,
    "curie_suffix": 5737,
    "id": "9a4bb391-4334-4bde-a8fe-8bacee3a6f44",
    "_version_": 1775179837774758000
  }
}
```