### PR TITLE
Report scores for reverse lookup

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -110,6 +110,7 @@ class LookupResult(BaseModel):
     label: str
     synonyms: List[str]
     types: List[str]
+    score: float
 
 
 @app.get("/lookup",
@@ -253,7 +254,8 @@ async def lookup(string: str,
         "sort": "score DESC, curie_suffix ASC",
         "limit": limit,
         "offset": offset,
-        "filter": filters
+        "filter": filters,
+        "fields": "*, score"
     }
     logging.debug(f"Query: {json.dumps(params)}")
 
@@ -265,6 +267,7 @@ async def lookup(string: str,
         response.raise_for_status()
     response = response.json()
     output = [ LookupResult(curie=doc.get("curie", ""), label=doc.get("preferred_name", ""), synonyms=doc.get("names", []),
+                score=doc.get("score", ""),
                 types=[f"biolink:{d}" for d in doc.get("types", [])])
                for doc in response["response"]["docs"]]
 


### PR DESCRIPTION
This PR modifies the lookup endpoints so that we report the Solr scores for each result.

Example result:
```json
[
  {
    "curie": "UBERON:0000178",
    "label": "blood",
    "synonyms": [
      "Bld",
      "BLOOD",
      "blood",
      "Haema",
      "Blood",
      "Sanguis",
      "Blood, NOS",
      "whole blood",
      "Whole Blood",
      "Portion of blood",
      "peripheral blood",
      "vertebrate blood",
      "portion of blood",
      "Peripheral Blood",
      "Blood (substance)",
      "Reticuloendothelial System, Blood"
    ],
    "types": [
      "biolink:AnatomicalEntity",
      "biolink:PhysicalEssence",
      "biolink:OrganismalEntity",
      "biolink:SubjectOfInvestigation",
      "biolink:BiologicalEntity",
      "biolink:ThingWithTaxon",
      "biolink:NamedThing",
      "biolink:Entity",
      "biolink:PhysicalEssenceOrOccurrent"
    ],
    "score": 98.381294
  }
]
```

Closes #109 