### PR TITLE
Add an `autocomplete` flag

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -246,7 +246,7 @@ async def lookup(string: str,
     if autocomplete:
         query = f"({string_lc_escaped}) OR ({string_lc_escaped}*)"
     else:
-        query = string_lc_escaped
+        query = f"({string_lc_escaped})"
 
     # Apply filters as needed.
     # Biolink type filter


### PR DESCRIPTION
NameRes' /lookup endpoint was previously designed for the autocomplete use-case, where we expect to give good results even when the search term is incomplete (e.g. `diab` instead of `diabetes`). We handled this by expanding the search to `({query}) OR ({query}*)`. This PR adds an `autocomplete` flag that allows this expansion to be turned on and off -- this should help improve our accuracy when NameRes is used for named entity linking only.

Closes #108.