### PR TITLE
Added instruction to make data/synonyms directory in target data/synonyms/done

### DIFF
--- a/data-loading/Makefile
+++ b/data-loading/Makefile
@@ -31,6 +31,7 @@ clean:
 #
 # Step 1. Download an uncompress synonym files.
 data/synonyms/done:
+	mkdir -p data/synonyms
 	wget -c -r -l1 -nd -P data/synonyms ${SYNONYMS_URL}
 	gunzip data/synonyms/*.txt.gz
 	echo Downloaded synonyms from ${SYNONYMS_URL}


### PR DESCRIPTION
Makes it unnecessary to create that directory manually. The `-p` flag on `mkdir` should ensure that no error occurs if the directory already exists.

Closes #106.