### PR TITLE
Update download path for NameRes data-loading

### DIFF
--- a/data-loading/Makefile
+++ b/data-loading/Makefile
@@ -5,7 +5,7 @@
 #
 
 # Configuration
-SYNONYMS_URL=https://stars.renci.org/var/babel_outputs/2022dec2-2/synonyms/
+SYNONYMS_URL=https://stars.renci.org/var/babel_outputs/2023nov5/synonyms/
 
 # How much memory should Solr use.
 SOLR_MEM=220G


### PR DESCRIPTION
We've been including the download path for Babel 2022dec2-2. This PR updates that to the version currently on Translator Test, which is 2023nov5.