### PR TITLE
Added support for multitype filtering

### DIFF
--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,7 +1,6 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,6 +1,7 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/api/server.py
+++ b/api/server.py
@@ -200,8 +200,9 @@ async def lookup_curies_get(
                         "e.g. `biolink:Disease` or `Disease`. Multiple types will be combined with OR, i.e. filtering "
                         "for PhenotypicFeature and Disease will return concepts that are either PhenotypicFeatures OR "
                         "Disease, not concepts that are both PhenotypicFeature AND Disease.",
-            # We can't use `example` here because otherwise it gets filled in when filling this in.
-            example=["biolink:Disease", "biolink:PhenotypicFeature"]
+            # We can't use `example` here because otherwise it gets filled in when you click "Try it out",
+            # which is easy to overlook.
+            # example=["biolink:Disease", "biolink:PhenotypicFeature"]
         )] = [],
         only_prefixes: Annotated[Union[str, None], Query(
             description="Pipe-separated, case-sensitive list of prefixes to filter to, e.g. `MONDO|EFO`.",
@@ -258,8 +259,9 @@ async def lookup_curies_post(
                         "e.g. `biolink:Disease` or `Disease`. Multiple types will be combined with OR, i.e. filtering "
                         "for PhenotypicFeature and Disease will return concepts that are either PhenotypicFeatures OR "
                         "Disease, not concepts that are both PhenotypicFeature AND Disease.",
-            # We can't use `example` here because otherwise it gets filled in when filling this in.
-            example=["biolink:Disease", "biolink:PhenotypicFeature"]
+            # We can't use `example` here because otherwise it gets filled in when you click "Try it out",
+            # which is easy to overlook.
+            # example=["biolink:Disease", "biolink:PhenotypicFeature"]
         )] = [],
         only_prefixes: Annotated[Union[str, None], Query(
             description="Pipe-separated, case-sensitive list of prefixes to filter to, e.g. `MONDO|EFO`.",

--- a/api/server.py
+++ b/api/server.py
@@ -195,11 +195,14 @@ async def lookup_curies_get(
             ge=0,
             le=1000
         )] = 10,
-        biolink_type: Annotated[Union[str, None], Query(
-            description="The Biolink type to filter to (with or without the `biolink:` prefix), e.g. `biolink:Disease` or `Disease`.",
+        biolink_type: Annotated[Union[List[str], None], Query(
+            description="The Biolink types to filter to (with or without the `biolink:` prefix), "
+                        "e.g. `biolink:Disease` or `Disease`. Multiple types will be combined with OR, i.e. filtering "
+                        "for PhenotypicFeature and Disease will return concepts that are either PhenotypicFeatures OR "
+                        "Disease, not concepts that are both PhenotypicFeature AND Disease.",
             # We can't use `example` here because otherwise it gets filled in when filling this in.
-            # example="biolink:Disease"
-        )] = None,
+            example=["biolink:Disease", "biolink:PhenotypicFeature"]
+        )] = [],
         only_prefixes: Annotated[Union[str, None], Query(
             description="Pipe-separated, case-sensitive list of prefixes to filter to, e.g. `MONDO|EFO`.",
             # We can't use `example` here because otherwise it gets filled in when filling this in.
@@ -250,11 +253,14 @@ async def lookup_curies_post(
             ge=0,
             le=1000
         )] = 10,
-        biolink_type: Annotated[Union[str, None], Query(
-            description="The Biolink type to filter to (with or without the `biolink:` prefix), e.g. `biolink:Disease` or `Disease`.",
+        biolink_type: Annotated[Union[List[str], None], Query(
+            description="The Biolink types to filter to (with or without the `biolink:` prefix), "
+                        "e.g. `biolink:Disease` or `Disease`. Multiple types will be combined with OR, i.e. filtering "
+                        "for PhenotypicFeature and Disease will return concepts that are either PhenotypicFeatures OR "
+                        "Disease, not concepts that are both PhenotypicFeature AND Disease.",
             # We can't use `example` here because otherwise it gets filled in when filling this in.
-            # example="biolink:Disease"
-        )] = None,
+            example=["biolink:Disease", "biolink:PhenotypicFeature"]
+        )] = [],
         only_prefixes: Annotated[Union[str, None], Query(
             description="Pipe-separated, case-sensitive list of prefixes to filter to, e.g. `MONDO|EFO`.",
             # We can't use `example` here because otherwise it gets filled in when filling this in.


### PR DESCRIPTION
This PR adds support for multitype filtering without changing the API: you can continue to use `biolink_type=Disease` if you want to filter with a single Biolink type, but you can also specify `biolink_type=Disease&biolink_type=PhenotypicFeature` if you want to find concepts that are EITHER (not both) biolink:Disease or biolink:PhenotypicFeature.

Closes #157.