### PR TITLE
Fix issue with empty Biolink type

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -333,9 +333,11 @@ async def lookup(string: str,
     if biolink_types:
         biolink_types_filters = []
         for biolink_type in biolink_types:
-            if biolink_type.startswith('biolink:'):
-                biolink_type = biolink_type[8:]
-            biolink_types_filters.append(f"types:{biolink_type}")
+            biolink_type_stripped = biolink_type.strip()
+            if biolink_type_stripped:
+                if biolink_type_stripped.startswith('biolink:'):
+                    biolink_type_stripped = biolink_type_stripped[8:]
+                biolink_types_filters.append(f"types:{biolink_type_stripped}")
         filters.append(" OR ".join(biolink_types_filters))
 
     # Prefix: only filter

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8,7 +8,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 def test_simple_check():
     client = TestClient(app)
-    params = {'string':'alzheimer'}
+    params = {'string':'alzheimer', 'biolink_type': ''}
     response = client.post("/lookup",params=params)
     syns = response.json()
     #There are more than 10, but it should cut off at 10 if we don't give it a max?


### PR DESCRIPTION
The previous PR (#158) introduced a bug that could be triggered by sending `biolink_type=''` to NameRes. This PR fixes that issue, and adds a test for this to the test suite.