### PR TITLE
Searching for an empty string now returns an empty list

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -307,6 +307,10 @@ async def lookup(string: str,
         will be returned, rather than filtering to concepts that are both PhenotypicFeature and Disease.
     """
 
+    # Do we have a search string at all?
+    if string.strip() == "":
+        return []
+
     # First, we lowercase the query since all our indexes are case-insensitive.
     string_lc = string.lower()
 
@@ -492,5 +496,5 @@ if os.environ.get('OTEL_ENABLED', 'false') == 'true':
     provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)
     FastAPIInstrumentor.instrument_app(app, tracer_provider=provider, excluded_urls=
-                                       "docs,openapi.json")    
+                                       "docs,openapi.json")
     HTTPXClientInstrumentor().instrument()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -16,6 +16,7 @@ def test_simple_check():
 
 
 def test_empty():
+    """ Checks that calling NameRes without an input string return an empty list. """
     client = TestClient(app)
     response = client.get("/lookup", params={'string':''})
     syns = response.json()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -14,6 +14,14 @@ def test_simple_check():
     #There are more than 10, but it should cut off at 10 if we don't give it a max?
     assert len(syns) == 10
 
+
+def test_empty():
+    client = TestClient(app)
+    response = client.get("/lookup", params={'string':''})
+    syns = response.json()
+    assert len(syns) == 0
+
+
 def test_limit():
     client = TestClient(app)
     params = {'string': 'alzheimer', 'limit': 1}


### PR DESCRIPTION
This PR catches cases where NameRes is queried with an empty string, and causes it to return an empty set of results.

(Currently we actually return everything in our index sorted from the highest clique count to the lowest, which is cute but not really necessary.)

Closes #131.