### PR TITLE
Update OTEL to gRPC

### DIFF
--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,7 +1,6 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,6 +1,7 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/api/server.py
+++ b/api/server.py
@@ -495,7 +495,7 @@ app.openapi_schema = construct_open_api_schema(app)
 if os.environ.get('OTEL_ENABLED', 'false') == 'true':
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
     from opentelemetry import trace
-    from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
     from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -508,19 +508,19 @@ if os.environ.get('OTEL_ENABLED', 'false') == 'true':
     # these supresses such warnings.
     logging.captureWarnings(capture=True)
     warnings.filterwarnings("ignore", category=ResourceWarning)
-    plater_service_name = os.environ.get('SERVER_NAME', 'infores:sri-name-resolver')
-    assert plater_service_name and isinstance(plater_service_name, str)
+    otel_service_name = os.environ.get('SERVER_NAME', 'infores:sri-node-normalizer')
+    assert otel_service_name and isinstance(otel_service_name, str)
 
-    jaeger_exporter = JaegerExporter(
-        agent_host_name=os.environ.get("JAEGER_HOST", "localhost"),
-        agent_port=int(os.environ.get("JAEGER_PORT", "6831")),
-    )
-    resource = Resource(attributes={
-        SERVICE_NAME: os.environ.get("JAEGER_SERVICE_NAME", plater_service_name),
+    otlp_host = os.environ.get("JAEGER_HOST", "http://localhost/").rstrip('/')
+    otlp_port = os.environ.get("JAEGER_PORT", "4317")
+    otlp_endpoint = f'{otlp_host}:{otlp_port}'
+    otlp_exporter = OTLPSpanExporter(endpoint=f'{otlp_endpoint}')
+    processor = BatchSpanProcessor(otlp_exporter)
+    # processor = BatchSpanProcessor(ConsoleSpanExporter())
+    resource = Resource.create(attributes={
+        SERVICE_NAME: os.environ.get("JAEGER_SERVICE_NAME", otel_service_name),
     })
     provider = TracerProvider(resource=resource)
-    # processor = BatchSpanProcessor(ConsoleSpanExporter())
-    processor = BatchSpanProcessor(jaeger_exporter)
     provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)
     FastAPIInstrumentor.instrument_app(app, tracer_provider=provider, excluded_urls=

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jsonlines
 
 # For testing
 pytest
-opentelemetry-sdk==1.21.0
-opentelemetry-exporter-jaeger==1.21.0
-opentelemetry-instrumentation-fastapi==0.42b0
-opentelemetry-instrumentation-httpx==0.42b0
+opentelemetry-sdk==1.27.0
+opentelemetry-exporter-otlp-proto-grpc==1.27.0
+opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-instrumentation-httpx==0.48b0


### PR DESCRIPTION
This PR copies over the code from https://github.com/TranslatorSRI/NodeNormalization/pull/298 in order to replace Jaeger with gRPC in OTEL telemetry collection.