### PR TITLE
Fix reverse CURIE endpoint

### DIFF
--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,7 +1,6 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,6 +1,7 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/api/server.py
+++ b/api/server.py
@@ -112,6 +112,16 @@ class SynonymsRequest(BaseModel):
     tags=["lookup"],
     deprecated=True,
 )
+async def reverse_lookup_get(
+        curies: List[str]= Query(
+            example=["MONDO:0005737", "MONDO:0009757"],
+            description="A list of CURIEs to look up synonyms for."
+        )
+) -> Dict[str, Dict]:
+    """Returns a list of synonyms for a particular CURIE."""
+    return await reverse_lookup(curies)
+
+
 @app.get(
     "/synonyms",
     summary="Look up synonyms for a CURIE.",


### PR DESCRIPTION
Unfortunately, https://github.com/TranslatorSRI/NameResolution/pull/168 renamed the parameter for the deprecated endpoint `/reverse_lookup` from `curies` to `preferred_curies`. This PR undoes that.