### PR TITLE
Bugfix: queries ending with whitespace with autocomplete=true searched for everything

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -345,12 +345,12 @@ async def lookup(string: str,
         will be returned, rather than filtering to concepts that are both PhenotypicFeature and Disease.
     """
 
-    # Do we have a search string at all?
-    if string.strip() == "":
-        return []
+    # First, we strip and lowercase the query since all our indexes are case-insensitive.
+    string_lc = string.strip().lower()
 
-    # First, we lowercase the query since all our indexes are case-insensitive.
-    string_lc = string.lower()
+    # Do we have a search string at all?
+    if string_lc == "":
+        return []
 
     # For reasons I don't understand, we need to use backslash to escape characters (e.g. "\(") to remove the special
     # significance of characters inside round brackets, but not inside double-quotes. So we escape them separately:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -128,6 +128,17 @@ def test_autocomplete():
     assert syns[1]["label"] == 'Alzheimer disease 6'
     assert syns[1]["types"][0] == "biolink:Disease"
 
+    # Previously, searching for an autocomplete query ending in whitespace
+    # would trigger a blank search (e.g. `abc ` would be expanded into `abc *`).
+    params = {'string': 'beta-secretase ', 'autocomplete': 'true'}
+    response = client.post("/lookup", params=params)
+    syns = response.json()
+
+    # When this was the case, it would result in the following:
+    # assert len(syns) == 10
+    # assert syns[0]['curie'] == 'CHEBI:48407'
+    # assert syns[0]["label"] == 'antiparkinson agent'
+    # assert syns[0]["types"] == ["biolink:NamedThing"]
 
 def test_bulk_lookup():
     client = TestClient(app)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -146,6 +146,7 @@ def test_autocomplete():
     assert syns[0]["label"] == 'BACE1 inhibitor'
     assert syns[0]["types"] == ["biolink:NamedThing"]
 
+
 def test_bulk_lookup():
     client = TestClient(app)
     params = {

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -134,11 +134,17 @@ def test_autocomplete():
     response = client.post("/lookup", params=params)
     syns = response.json()
 
-    # When this was the case, it would result in the following:
+    # When this bug was around, it would result in the following:
     # assert len(syns) == 10
     # assert syns[0]['curie'] == 'CHEBI:48407'
     # assert syns[0]["label"] == 'antiparkinson agent'
     # assert syns[0]["types"] == ["biolink:NamedThing"]
+
+    # But now we only get beta-secretase.
+    assert len(syns) == 1
+    assert syns[0]['curie'] == 'CHEBI:74925'
+    assert syns[0]["label"] == 'BACE1 inhibitor'
+    assert syns[0]["types"] == ["biolink:NamedThing"]
 
 def test_bulk_lookup():
     client = TestClient(app)


### PR DESCRIPTION
This is because if the query was e.g. `"abc "`, we would expand it to `"abc *"`. This PR updates the code to strip the query string before querying it, which fixes this issue.