### PR TITLE
Added NameRes release information for November 2024 and January 2025

### DIFF
--- a/releases/TranslatorGuppyAugust2024.md
+++ b/releases/TranslatorGuppyAugust2024.md
@@ -2,7 +2,7 @@
 - Babel: [2024aug18](https://stars.renci.org/var/babel_outputs/2024aug18/)
   ([Babel Translator "Guppy" August 2024 Release](https://github.com/TranslatorSRI/Babel/blob/master/releases/TranslatorGuppyAugust2024.md))
 - NameRes: [v1.4.3](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.3)
-Next release: _None as yet_
+Next release: [Translator "Hammerhead" November 2024](./TranslatorHammerheadNovember2024.md)
 Previous release: [Translator "Fugu" July 2024](./TranslatorFuguJuly2024.md)
 
 ## New features

--- a/releases/TranslatorHammerheadNovember2024.md
+++ b/releases/TranslatorHammerheadNovember2024.md
@@ -1,0 +1,27 @@
+# NameRes Translator "Hammerhead" November 2024 Release
+- Babel: [2024oct24](https://stars.renci.org/var/babel_outputs/2024oct24/)
+  ([Babel Translator November 2024 Release](https://github.com/TranslatorSRI/Babel/blob/master/releases/TranslatorHammerheadNovember2024.md))
+- NameRes: [v1.4.5](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.5)
+Next release: [NameRes v1.4.7](./v1.4.7.md)
+Previous release: [Translator "Guppy" August 2024](./TranslatorGuppyAugust2024.md)
+
+## New features
+* Searching for an empty string now returns an empty list in [#167](https://github.com/TranslatorSRI/NameResolution/pull/167).
+
+## Cleanup and improvements
+* Add an MIT license for NameRes in [#169](https://github.com/TranslatorSRI/NameResolution/pull/169).
+* Delete tests/data/test-synonyms.jsonl, which does not appear to be used in [#170](https://github.com/TranslatorSRI/NameResolution/pull/170).
+
+## Babel updates (from [Babel Translator "Hammerhead" November 2024 Release](https://github.com/TranslatorSRI/Babel/blob/master/releases/TranslatorHammerheadNovember2024.md))
+- [New features] Added taxon information to proteins ([#349](https://github.com/TranslatorSRI/Babel/pull/349))
+- [Updates] Upgraded RxNorm to 09032024.
+- [Updates] Changed NCBIGene download from FTP to HTTP.
+- [Updates] Increased DRUG_CHEMICAL_SMALLER_MAX_LABEL_LENGTH (introduced in [#330](https://github.com/TranslatorSRI/Babel/pull/330)) from 30 to 40.
+
+## Releases since [Translator "Guppy" August 2024](./TranslatorGuppyAugust2024.md)
+* [1.4.5](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.5)
+  * Searching for an empty string now returns an empty list in [#167](https://github.com/TranslatorSRI/NameResolution/pull/167).
+  * Add an MIT license for NameRes in [#169](https://github.com/TranslatorSRI/NameResolution/pull/169).
+  * Delete tests/data/test-synonyms.jsonl, which does not appear to be used in [#170](https://github.com/TranslatorSRI/NameResolution/pull/170).
+* [1.4.4](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.4)
+  * Added release notes for Translator Guppy in [#160](https://github.com/TranslatorSRI/NameResolution/pull/160).

--- a/releases/v1.4.7.md
+++ b/releases/v1.4.7.md
@@ -1,0 +1,39 @@
+# NameRes v1.4.7 Release
+- Babel: [2025jan23](https://stars.renci.org/var/babel_outputs/2025jan23/)
+  ([Babel 2025jan23](https://github.com/TranslatorSRI/Babel/blob/master/releases/2025jan23.md))
+- NameRes: [v1.4.7](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.7)
+Next release: _None as yet_
+Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerheadNovember2024.md)
+
+## New Features
+* Add a bulk endpoint for NameRes in [#165](https://github.com/TranslatorSRI/NameResolution/pull/165).
+
+## Improvements
+* Replaces /reverse_lookup with a more sensible name in [#168](https://github.com/TranslatorSRI/NameResolution/pull/168).
+* Update OTEL to gRPC in [#171](https://github.com/TranslatorSRI/NameResolution/pull/171).
+
+## Bugfixes
+* Fix reverse CURIE endpoint in [#172](https://github.com/TranslatorSRI/NameResolution/pull/172).
+* Queries ending with whitespace with autocomplete=true searched for everything by @gaurav in #173
+
+## Babel updates (from [Babel 2025jan23](https://github.com/TranslatorSRI/Babel/blob/master/releases/2025jan23.md))
+- [New feature] Added a check for duplicate CURIEs [#342](https://github.com/TranslatorSRI/Babel/pull/342).
+- [New feature] Added some additional manual concords for Disease/Phenotype cliques and DrugChemical
+  conflation [#360](https://github.com/TranslatorSRI/Babel/pull/360).
+- [New feature] Replace use of `has_tradename` with `tradename_of` in RxNorm ([#377](https://github.com/TranslatorSRI/Babel/pull/377)).
+- [New feature] Added processes from UMLS ([#395](https://github.com/TranslatorSRI/Babel/pull/395)).
+- [New feature] Improved EFO relationships ([#396](https://github.com/TranslatorSRI/Babel/pull/396)).
+- [Updates] Various updates
+- [Bugfix] Fixed a bug in choosing the best label shorter than a particular size in src/babel_utils.py:write_compendium()
+- [Bugfix] Cleaned up src/createcompendia/chemicals.py:parse_smifile() so that includes the ChEMBL ID and calculates the column index by name, with ValueErrors thrown if the column name is missing.
+- [Bugfix] Filtered out `.nfs*` files from the file list tests, which appear sometimes on Sterling as a NFS file issues.
+- [Bugfix] Other minor fixes.
+
+## Releases since [Translator "Hammerhead" November 2024](./TranslatorHammerheadNovember2024.md)
+* [1.4.7](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.7)
+  * Replaces /reverse_lookup with a more sensible name by @gaurav in #168
+  * Update OTEL to gRPC by @gaurav in #171
+  * Fix reverse CURIE endpoint by @gaurav in #172
+  * Add a bulk endpoint for NameRes by @gaurav in #165
+* [1.4.6](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.6)
+  * Bugfix: queries ending with whitespace with autocomplete=true searched for everything in [#173](https://github.com/TranslatorSRI/NameResolution/pull/173)


### PR DESCRIPTION
This PR adds NameRes release information for November 2024 and January 2025.