### PR TITLE
Added Babel version and Babel version URL

### DIFF
--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,7 +1,6 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-name-resolution.yml
+++ b/.github/workflows/release-name-resolution.yml
@@ -1,6 +1,7 @@
 name: 'Release a new version of NameResolution to Github Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/api/server.py
+++ b/api/server.py
@@ -67,6 +67,10 @@ async def status() -> Dict:
         response.raise_for_status()
     result = response.json()
 
+    # Do we know the Babel version and version URL? It will be stored in an environmental variable if we do.
+    babel_version = os.environ.get("BABEL_VERSION", "unknown")
+    babel_version_url = os.environ.get("BABEL_VERSION_URL", "")
+
     # We should have a status for name_lookup_shard1_replica_n1.
     if 'status' in result and 'name_lookup_shard1_replica_n1' in result['status']:
         core = result['status']['name_lookup_shard1_replica_n1']
@@ -78,6 +82,8 @@ async def status() -> Dict:
         return {
             'status': 'ok',
             'message': 'Reporting results from primary core.',
+            'babel_version': babel_version,
+            'babel_version_url': babel_version_url,
             'startTime': core['startTime'],
             'numDocs': index.get('numDocs', ''),
             'maxDoc': index.get('maxDoc', ''),


### PR DESCRIPTION
This PR adds a `babel_version` and `babel_version_url` to `/status`, which we get from the `BABEL_VERSION` and `BABEL_VERSION_URL` environmental variables, which we will set in the Helm chart.