### PR TITLE
Add release notes for NameRes v1.5.0

### DIFF
--- a/releases/v1.5.0.md
+++ b/releases/v1.5.0.md
@@ -1,0 +1,46 @@
+# NameRes v1.5.0 Release
+- Babel: [2025sep1](https://stars.renci.org/var/babel_outputs/2025sep1/)
+  ([Babel 2025sep1](https://github.com/TranslatorSRI/Babel/blob/master/releases/2025sep1.md))
+- NameRes: [v1.5.0](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.5.0)
+Next release: _None as yet_
+Previous release: [NameRes v1.4.7](./v1.4.7.md)
+
+## Bugfixes
+- [MAJOR] Entries with clique_identifier_count=1 were being filtered out of search results because we were boosting
+  with the log of clique_identifier_count, and log(1) = 0. This has now been fixed by using the log of
+  (clique_identifier_count + 1). ([PR #179](https://github.com/TranslatorSRI/NameResolution/pull/179))
+- Fixed bug in NameRes Loading Docker image generation (d3f607af95e3fb254298d7f0a637a63ccb63fd6b).
+
+## New Features
+- [MAJOR] This NameRes has GeneProtein conflation turned on. If you need to know the protein and gene identifiers for
+  a particular NameRes result, you can normalize the identifier with the corresponding NodeNorm instance with
+  `individual_types` set to true ([example](https://nodenormalization-sri.renci.org/1.5/get_normalized_nodes?curie=NCBIGene%3A1756&conflate=true&drug_chemical_conflate=false&description=false&individual_types=true)).
+- Added Babel version and version URL to the `/status` endpoint ([PR #180](https://github.com/TranslatorSRI/NameResolution/pull/180)).
+- Added instructions and script for running NameRes locally ([PR #186](https://github.com/TranslatorSRI/NameResolution/pull/186)).
+
+## Improvements
+- [MAJOR] Update exact boosts ([PR #183](https://github.com/TranslatorSRI/NameResolution/pull/183)).
+  - Exactish (case-insensitive exact) matches are now boosted by ~100x non-exactish matches.
+  - Increased the basic boost by ~10x so that they override low clique_identifier_count matches.
+- Updated curl to use -T instead of -d to upload file in data-loading ([PR #183](https://github.com/TranslatorSRI/NameResolution/pull/197)).
+- Fix start-end quotes bug (i.e. "smart" quotes) ([PR #179](https://github.com/TranslatorSRI/NameResolution/pull/179)).
+
+## Babel updates (from [Babel 2025sep1](https://github.com/TranslatorSRI/Babel/blob/master/releases/2025sep1.md))
+
+
+## Releases since [NameRes v1.4.7](./v1.4.7.md)
+- [NameRes v1.4.8](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.8)
+  - Added NameRes release information for November 2024 and January 2025 by @gaurav in #177
+- [NameRes v1.4.9](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.9)
+  - Incremented version number (forgot to do that in NameRes v1.4.8).
+- [NameRes v1.4.10](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.10)
+  - Added Babel version and Babel version URL by @gaurav in #180
+- [NameRes v1.4.11](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.11)
+  - Add instructions and script for running NameRes locally by @gaurav in #186
+- [NameRes v1.4.12](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.4.12)
+  - Replace renci-python-image with GitHub Packages (d3f607a).
+- [NameRes v1.5.0](https://github.com/TranslatorSRI/NameResolution/releases/tag/v1.5.0)
+  - [MAJOR] Entries with clique_identifier_count=1 were being filtered out of search results because we were boosting with the log of clique_identifier_count, and log(1) = 0. This has now been fixed by using the log of (clique_identifier_count + 1) in #179.
+  - [MAJOR] Tweaked exact boosts by @gaurav in #183
+  - Updated curl to use -T instead of -d to upload file in data-loading by @gaurav in #197
+  - Fix start-end quotes bug and stopped filtering out clique_identifier_count=1 records by @gaurav in #179


### PR DESCRIPTION
This PR adds release notes for NameRes v1.5.0.

WIP: I need to add the Babel changelog.