### PR TITLE
Include non taxa entries with only_taxa

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -474,7 +474,7 @@ async def lookup(string: str,
         "fields": "*, score",
         "params": inner_params,
     }
-    logging.debug(f"Query: {json.dumps(params, indent=2)}")
+    print(f"Query: {json.dumps(params, indent=2)}")
 
     query_url = f"http://{SOLR_HOST}:{SOLR_PORT}/solr/name_lookup/select"
     async with httpx.AsyncClient(timeout=None) as client:


### PR DESCRIPTION
Running a query with only_taxa set to any taxa causes it to filter out any result that isn't assigned to any taxa (#193). This is confusing behavior. This PR attempts (unsuccessfully so far) to modify the Solr query so that setting only_taxa should include results that include NO taxa as well as those at include one of the correct taxa.

WIP