### PR TITLE
Stop storing names_exactish

### DIFF
--- a/data-loading/setup-and-load-solr.sh
+++ b/data-loading/setup-and-load-solr.sh
@@ -73,7 +73,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
             "name":"names_exactish",
             "type":"exactish",
             "indexed":true,
-            "stored":true,
+            "stored":false,
             "multiValued":true
         },
         {


### PR DESCRIPTION
We don't store preferred_names_exactish, so why names_exactish?