### PR TITLE
Add logging

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -205,7 +205,7 @@ async def curie_lookup(curies) -> Dict[str, Dict]:
         output[doc["curie"]] = doc
     time_end = time.time_ns()
 
-    logging.info(f"CURIE Lookup on {len(curies)} CURIEs {json.dumps(curies)} took {(time_end - time_start)/1_000_000:.2f}ms")
+    logger.info(f"CURIE Lookup on {len(curies)} CURIEs {json.dumps(curies)} took {(time_end - time_start)/1_000_000:.2f}ms")
     
     return output
 
@@ -532,7 +532,7 @@ async def lookup(string: str,
                            types=[f"biolink:{d}" for d in doc.get("types", [])]))
 
     time_end = time.time_ns()
-    logging.info(f"Lookup query to Solr for {json.dumps(string)} " +
+    logger.info(f"Lookup query to Solr for {json.dumps(string)} " +
                  f"(autocomplete={autocomplete}, highlighting={highlighting}, offset={offset}, limit={limit}, biolink_types={biolink_types}, only_prefixes={only_prefixes}, exclude_prefixes={exclude_prefixes}, only_taxa={only_taxa}) "
                  f"took {(time_end - time_start)/1_000_000:.2f}ms (with {(time_solr_end - time_solr_start)/1_000_000:.2f}ms waiting for Solr)"
     )
@@ -605,6 +605,7 @@ class NameResQuery(BaseModel):
           tags=["lookup"]
 )
 async def bulk_lookup(query: NameResQuery) -> Dict[str, List[LookupResult]]:
+    time_start = time.time_ns()
     result = {}
     for string in query.strings:
         result[string] = await lookup(
@@ -617,6 +618,9 @@ async def bulk_lookup(query: NameResQuery) -> Dict[str, List[LookupResult]]:
             query.only_prefixes,
             query.exclude_prefixes,
             query.only_taxa)
+    time_end = time.time_ns()
+    logger.info(f"Bulk lookup query for {len(query.strings)} strings ({query}) took {(time_end - time_start)/1_000_000:.2f}ms")
+
     return result
 
 


### PR DESCRIPTION
This PR adds logging to all NameRes endpoints so we can track how long queries take. Will help with #107 and #228.

It also adds an environmental variable (`LOGLEVEL`) that controls the log level.